### PR TITLE
Fixing Username Save Error

### DIFF
--- a/DoodleNote.Tests/Areas/Identity/Pages/Account/Manage/IndexModelTests.cs
+++ b/DoodleNote.Tests/Areas/Identity/Pages/Account/Manage/IndexModelTests.cs
@@ -1,0 +1,97 @@
+#nullable enable
+using System.IO;
+using System.Security.Claims;
+using System.Text;
+using System.Threading.Tasks;
+using DoodleNote.Areas.Identity.Pages.Account.Manage;
+using DoodleNote.Features.Admin.Models;
+using DoodleNote.Models;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.AspNetCore.Mvc.Routing;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using Xunit;
+
+namespace DoodleNote.Tests.Areas.Identity.Pages.Account.Manage;
+
+public class IndexModelTests
+{
+    [Fact]
+    public async Task OnPostUpdateUsernameAsync_UpdatesUsername_AndRefreshesSignIn()
+    {
+        var user = new ApplicationUser
+        {
+            Id = "user-id",
+            UserName = "old_name"
+        };
+
+        var userManagerMock = CreateUserManagerMock();
+        userManagerMock.Setup(manager => manager.GetUserAsync(It.IsAny<ClaimsPrincipal>())).ReturnsAsync(user);
+        userManagerMock.Setup(manager => manager.FindByNameAsync("new_name")).ReturnsAsync((ApplicationUser?)null);
+        userManagerMock
+            .Setup(manager => manager.SetUserNameAsync(user, "new_name"))
+            .ReturnsAsync(IdentityResult.Success)
+            .Callback<ApplicationUser, string>((targetUser, newUserName) => targetUser.UserName = newUserName);
+
+        var signInManagerMock = CreateSignInManagerMock(userManagerMock.Object);
+        signInManagerMock.Setup(manager => manager.RefreshSignInAsync(user)).Returns(Task.CompletedTask);
+
+        var pageModel = new IndexModel(userManagerMock.Object, signInManagerMock.Object, Mock.Of<ILogger<IndexModel>>());
+        pageModel.PageContext = CreatePageContext("{\"newUsername\":\"new_name\"}");
+
+        IActionResult result = await pageModel.OnPostUpdateUsernameAsync();
+
+        var jsonResult = Assert.IsType<JsonResult>(result);
+        Assert.Null(jsonResult.StatusCode);
+        Assert.Equal("new_name", user.UserName);
+        signInManagerMock.Verify(manager => manager.RefreshSignInAsync(user), Times.Once);
+        userManagerMock.Verify(manager => manager.SetUserNameAsync(user, "new_name"), Times.Once);
+    }
+
+    private static Mock<UserManager<ApplicationUser>> CreateUserManagerMock()
+    {
+        var store = new Mock<IUserStore<ApplicationUser>>();
+        return new Mock<UserManager<ApplicationUser>>(
+            store.Object,
+            null!,
+            null!,
+            null!,
+            null!,
+            null!,
+            null!,
+            null!,
+            null!);
+    }
+
+    private static Mock<SignInManager<ApplicationUser>> CreateSignInManagerMock(UserManager<ApplicationUser> userManager)
+    {
+        var contextAccessor = new Mock<IHttpContextAccessor>();
+        var claimsFactory = new Mock<IUserClaimsPrincipalFactory<ApplicationUser>>();
+        return new Mock<SignInManager<ApplicationUser>>(
+            userManager,
+            contextAccessor.Object,
+            claimsFactory.Object,
+            null!,
+            null!,
+            null!,
+            null!);
+    }
+
+    private static PageContext CreatePageContext(string requestBody)
+    {
+        var httpContext = new DefaultHttpContext();
+        httpContext.User = new ClaimsPrincipal(new ClaimsIdentity(new[]
+        {
+            new Claim(ClaimTypes.NameIdentifier, "user-id")
+        }, "TestAuth"));
+        httpContext.Request.Body = new MemoryStream(Encoding.UTF8.GetBytes(requestBody));
+        httpContext.RequestServices = new ServiceCollection().BuildServiceProvider();
+
+        return new PageContext(new ActionContext(httpContext, new RouteData(), new PageActionDescriptor()));
+    }
+}

--- a/DoodleNote/Areas/Identity/Pages/Account/Manage/Index.cshtml.cs
+++ b/DoodleNote/Areas/Identity/Pages/Account/Manage/Index.cshtml.cs
@@ -42,7 +42,6 @@ public class IndexModel : PageModel
 
 	public async Task<IActionResult> OnPostUpdateUsernameAsync()
 	{
-		Request.Body.Position = 0;
 		using var reader = new StreamReader(Request.Body);
 		var jsonBody = await reader.ReadToEndAsync();
 
@@ -115,7 +114,6 @@ public class IndexModel : PageModel
 
 	public async Task<IActionResult> OnPostUpdatePhoneAsync()
 	{
-		Request.Body.Position = 0;
 		using var reader = new StreamReader(Request.Body);
 		var jsonBody = await reader.ReadToEndAsync();
 

--- a/DoodleNote/Program.cs
+++ b/DoodleNote/Program.cs
@@ -20,6 +20,9 @@ builder.Services.AddDefaultIdentity<ApplicationUser>(options => options.SignIn.R
     .AddRoles<IdentityRole>()
     .AddEntityFrameworkStores<ApplicationDbContext>();
 
+builder.Services.AddAntiforgery(options =>
+    options.HeaderName = "X-CSRF-TOKEN");
+
 builder.Services.AddScoped<RoleService>();
 builder.Services.AddScoped<AccountService>();
 builder.Services.AddRazorPages();


### PR DESCRIPTION
CLoses #36

Remove redundant Request.Body.Position reset in username and phone update methods; add CSRF token configuration in Program.cs; implement unit tests for username update functionality.

This pull request adds a new unit test for updating a user's username, introduces CSRF protection via antiforgery headers, and makes minor cleanup to request body handling in account management endpoints. The most important changes are:

**Testing improvements:**

* Added a new test class `IndexModelTests` in `DoodleNote.Tests/Areas/Identity/Pages/Account/Manage/IndexModelTests.cs` to verify that updating a username via `OnPostUpdateUsernameAsync` correctly updates the username and refreshes the sign-in.

**Security enhancements:**

* Configured antiforgery protection by setting the `X-CSRF-TOKEN` header for requests in `DoodleNote/Program.cs`.

**Code cleanup:**

* Removed unnecessary `Request.Body.Position = 0;` statements from the `OnPostUpdateUsernameAsync` and `OnPostUpdatePhoneAsync` methods in `DoodleNote/Areas/Identity/Pages/Account/Manage/Index.cshtml.cs`. [[1]](diffhunk://#diff-8641b5b7b62b236433c0d0451ed6b3bb96a098939cf9f5fa9f7ea87d9ed38e73L45) [[2]](diffhunk://#diff-8641b5b7b62b236433c0d0451ed6b3bb96a098939cf9f5fa9f7ea87d9ed38e73L118)