### PR TITLE
Fix doodle note creation error

### DIFF
--- a/DoodleNote/Controllers/DoodleNotesController.cs
+++ b/DoodleNote/Controllers/DoodleNotesController.cs
@@ -44,6 +44,19 @@ public class DoodleNotesController(ApplicationDbContext context) : Controller
 		});
 	}
 
+	[HttpPost]
+	[ValidateAntiForgeryToken]
+	public async Task<IActionResult> Create([Bind("NoteTitle,Description")] DoodleNote.Models.DoodleNote note)
+	{
+		if (ModelState.IsValid)
+		{
+			note.CreatedDate = DateTime.Now;
+			_context.DoodleNotes.Add(note);
+			await _context.SaveChangesAsync();
+			return RedirectToAction(nameof(Index));
+		}
+		return View(note);
+	}
 
 	/// <summary>
 	/// Displays detailed view of a single note with formatted display model.

--- a/DoodleNote/Views/Doodle/Index.cshtml
+++ b/DoodleNote/Views/Doodle/Index.cshtml
@@ -197,7 +197,7 @@
                     method: 'POST',
                     headers: {
                         'Content-Type': 'application/json',
-                        'RequestVerificationToken': antiForgeryToken
+                        'X-CSRF-TOKEN': antiForgeryToken
                     },
                     body: JSON.stringify({ pngDataUrl: dataUrl })
                 });


### PR DESCRIPTION
Closes #43 

Fixed DoodleNoteController compiler issue created by tests not having a create method and adjusted antiforgerytoken header in Index.cshtml to look for header created in program.cs